### PR TITLE
fix box cloning issue

### DIFF
--- a/src/app/test_scripts/tests/0_box_cloning.sau
+++ b/src/app/test_scripts/tests/0_box_cloning.sau
@@ -1,0 +1,20 @@
+[box x [var y 100]]
+
+[var a [x]]
+[var b [x]]
+[var c [x]]
+
+[assert "box_cloning.sau > initial values " [== x.y a.y]]
+[assert "box_cloning.sau > initial values " [== x.y b.y]]
+[assert "box_cloning.sau > initial values " [== x.y c.y]]
+
+[set a.y 0]
+[set b.y 1]
+[set c.y 2]
+
+[assert "box_cloning.sau > check clone a-b " [!= a.y b.y]]
+[assert "box_cloning.sau > check clone a-c " [!= a.y c.y]]
+[assert "box_cloning.sau > check clone b-a " [!= b.y a.y]]
+[assert "box_cloning.sau > check clone b-c " [!= b.y c.y]]
+[assert "box_cloning.sau > check clone c-a " [!= c.y a.y]]
+[assert "box_cloning.sau > check clone c-b " [!= c.y b.y]]

--- a/src/libsauros/sauros/cell.hpp
+++ b/src/libsauros/sauros/cell.hpp
@@ -89,6 +89,10 @@ class cell_c {
    //! \param list The list to set in the cell
    cell_c(cells_t list) : type(cell_type_e::LIST), list(list) {}
 
+   //! \brief Clone the cell
+   //! \returns A new copy of the cell in a shared_ptr
+   cell_ptr clone() const { return std::shared_ptr<cell_c>(new cell_c(*this)); }
+
    // Data
    std::string data;
    cell_type_e type{cell_type_e::SYMBOL};

--- a/src/libsauros/sauros/environment.hpp
+++ b/src/libsauros/sauros/environment.hpp
@@ -5,6 +5,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <iostream>
+
 #include "cell_map.hpp"
 
 namespace sauros {
@@ -75,6 +77,9 @@ class environment_c {
    //! \post There will exist an item that maps the string to the cell
    //! \note If the item already exists, it will be overwritten
    void set(const std::string &item, cell_ptr cell);
+
+   //! \brief Retrieve a copy of the env map
+   cell_map_t get_map() const { return _env; }
 
  private:
    std::shared_ptr<environment_c> _parent{nullptr};

--- a/src/libsauros/sauros/processor/processor.cpp
+++ b/src/libsauros/sauros/processor/processor.cpp
@@ -193,6 +193,10 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
       //
       auto env_with_data = env->find(cell->data, cell->location);
       auto r = env_with_data->get(cell->data);
+
+      if (r->type == cell_type_e::BOX) {
+         return clone_box(r);
+      }
       return {r};
    }
 
@@ -256,6 +260,16 @@ cell_ptr processor_c::process_lambda(cell_ptr cell, cells_t &cells,
        environment_c(cell->list[0]->list, exps, env));
 
    return process_cell(lambda_cell, lambda_env);
+}
+
+cell_ptr processor_c::clone_box(cell_ptr cell) {
+
+   cell_c new_box(cell_type_e::BOX);
+   new_box.box_env = std::shared_ptr<environment_c>(new environment_c());
+   for (auto [key, value] : cell->box_env->get_map()) {
+      new_box.box_env->set(key, value->clone());
+   }
+   return std::make_shared<cell_c>(new_box);
 }
 
 cell_ptr processor_c::access_box_member(cell_ptr cell,

--- a/src/libsauros/sauros/processor/processor.hpp
+++ b/src/libsauros/sauros/processor/processor.hpp
@@ -107,6 +107,8 @@ class processor_c {
    cell_ptr process_lambda(cell_ptr cell, cells_t &cells,
                            std::shared_ptr<environment_c> env);
 
+   cell_ptr clone_box(cell_ptr cell);
+
    cell_ptr access_box_member(cell_ptr cell,
                               std::shared_ptr<environment_c> &env);
 


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [x] Branch name details the work done for the PR
- [x] CI tests have passed
- [x] An admin has reviewed and accepted the PR
- [x] Clang format has been run on changes (`run format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)


## Description of work:

Please enter a description of your work here:
```
Box types weren't being properly clones leading to all box instances pointing to the same cell. This fixes that by properly cloning the cell when given an instantiation of a cell.
```