### PR TITLE
fixed bug

### DIFF
--- a/examples/example_code/library_checkout_system/database/db.sau
+++ b/examples/example_code/library_checkout_system/database/db.sau
@@ -1,0 +1,18 @@
+;[import "database/entry.sau"]
+
+
+
+ [use "io"]
+
+
+[var db::load [lambda [file] [block 
+   ;[if [not [os.is_file "books.db"]] [[block
+   ;   [putln "Given item is not a file: " file]
+   ;   [exit 1]
+   ;]]]
+   ;[putln [os.os_name]]
+   [io.get_string "$"]
+
+   [putln "Looks like its a file"] 
+
+]]]

--- a/examples/example_code/library_checkout_system/database/entry.sau
+++ b/examples/example_code/library_checkout_system/database/entry.sau
@@ -1,0 +1,26 @@
+
+
+[box database::entry [block
+   [var title]
+   [var description]
+   [var status]
+]]
+
+[var database::new_entry [lambda [title description status] [
+   [var new_item [database::entry]]
+   [set new_item.title title]
+   [set new_item.description description]
+   [set new_item.status status]
+   [new_item]
+]]]
+
+[var database::print_entry [lambda [entry] [block
+   [use "fmt"]
+   [var formatted_entry 
+      [fmt.encode "Title: %\nDescription: %\nStatus: %\n" 
+                  [list entry.title entry.description entry.status]
+      ]
+   ]
+   [formatted_entry]
+]]]
+

--- a/examples/example_code/library_checkout_system/main.sau
+++ b/examples/example_code/library_checkout_system/main.sau
@@ -1,0 +1,14 @@
+;[import "database/db.sau"]
+
+[import "database/db.sau"]
+
+[var x [lambda [] [block
+
+   [db::load "moot"]
+ ;  [var x [io.get_int ">>"]]
+
+]]]
+
+;[var loaded_database [db::load "books.db"]]
+
+[x]

--- a/pkgs/os/os.cpp
+++ b/pkgs/os/os.cpp
@@ -200,7 +200,7 @@ sauros::cell_ptr _pkg_os_is_dir_(sauros::cells_t &cells,
    auto raw_dest = c_api_process_cell(cells[1], env);
    if (raw_dest->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "is_file command expects parameter to be a string",
+          "is_dir command expects parameter to be a string",
           cells[0]->location);
    }
 

--- a/src/libsauros/CMakeLists.txt
+++ b/src/libsauros/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SAUROS_SOURCES
    ${CMAKE_SOURCE_DIR}/sauros/environment.cpp
    ${CMAKE_SOURCE_DIR}/sauros/driver.cpp
    ${CMAKE_SOURCE_DIR}/sauros/capi/capi.cpp
+   ${CMAKE_SOURCE_DIR}/sauros/RLL/rll_wrapper.cpp
    ${CMAKE_SOURCE_DIR}/sauros/system/system.cpp
    ${CMAKE_SOURCE_DIR}/sauros/front/parser.cpp
    ${CMAKE_SOURCE_DIR}/sauros/processor/processor.cpp
@@ -85,7 +86,8 @@ set(HEADERS
    ${CMAKE_SOURCE_DIR}/sauros/front/parser.hpp
    ${CMAKE_SOURCE_DIR}/sauros/driver.hpp
    ${CMAKE_SOURCE_DIR}/sauros/rang.hpp
-   ${CMAKE_SOURCE_DIR}/sauros/capi/capi.cpp
+   ${CMAKE_SOURCE_DIR}/sauros/capi/capi.hpp
+   ${CMAKE_SOURCE_DIR}/sauros/RLL/rll_wrapper.hpp
    ${CMAKE_SOURCE_DIR}/sauros/system/system.hpp
    ${CMAKE_SOURCE_DIR}/sauros/processor/processor.hpp
    ${CMAKE_SOURCE_DIR}/sauros/environment.hpp

--- a/src/libsauros/sauros/RLL/rll_wrapper.cpp
+++ b/src/libsauros/sauros/RLL/rll_wrapper.cpp
@@ -1,0 +1,36 @@
+#include "rll_wrapper.hpp"
+
+#include "RLL.h"
+
+namespace sauros {
+
+rll_wrapper_c::rll_wrapper_c() : _lib(new rll::shared_library()) {
+}
+
+void rll_wrapper_c::load(std::string target) {
+   try {
+      _lib->load(target);
+   } catch (rll::exception::library_loading_error &e) {
+      throw library_loading_error_c(e.what());
+   }
+}
+
+bool rll_wrapper_c::is_loaded() {
+   return _lib->is_loaded();
+}
+
+bool rll_wrapper_c::has_symbol(std::string symbol) {
+   return _lib->has_symbol(symbol);
+}
+
+void* rll_wrapper_c::get_symbol(std::string symbol) {
+   return _lib->get_symbol(symbol);
+}
+
+std::shared_ptr<rll::shared_library> make_rll_lib() {
+   return std::shared_ptr<rll::shared_library>(
+      new rll::shared_library()
+   );
+}
+
+}

--- a/src/libsauros/sauros/RLL/rll_wrapper.cpp
+++ b/src/libsauros/sauros/RLL/rll_wrapper.cpp
@@ -4,8 +4,7 @@
 
 namespace sauros {
 
-rll_wrapper_c::rll_wrapper_c() : _lib(new rll::shared_library()) {
-}
+rll_wrapper_c::rll_wrapper_c() : _lib(new rll::shared_library()) {}
 
 void rll_wrapper_c::load(std::string target) {
    try {
@@ -15,22 +14,18 @@ void rll_wrapper_c::load(std::string target) {
    }
 }
 
-bool rll_wrapper_c::is_loaded() {
-   return _lib->is_loaded();
-}
+bool rll_wrapper_c::is_loaded() { return _lib->is_loaded(); }
 
 bool rll_wrapper_c::has_symbol(std::string symbol) {
    return _lib->has_symbol(symbol);
 }
 
-void* rll_wrapper_c::get_symbol(std::string symbol) {
+void *rll_wrapper_c::get_symbol(std::string symbol) {
    return _lib->get_symbol(symbol);
 }
 
 std::shared_ptr<rll::shared_library> make_rll_lib() {
-   return std::shared_ptr<rll::shared_library>(
-      new rll::shared_library()
-   );
+   return std::shared_ptr<rll::shared_library>(new rll::shared_library());
 }
 
-}
+} // namespace sauros

--- a/src/libsauros/sauros/RLL/rll_wrapper.hpp
+++ b/src/libsauros/sauros/RLL/rll_wrapper.hpp
@@ -1,0 +1,52 @@
+#ifndef SAUROS_RLL_WRAPPER
+#define SAUROS_RLL_WRAPPER
+
+#include <memory>
+#include <string>
+#include "sauros/parallel_hashmap/phmap.hpp"
+
+// Forward declaration for RLL library loader
+namespace rll {
+class shared_library;
+}
+
+namespace sauros {
+   
+//! \brief A wrapper fo the rll lib as the header can only be included
+//!        once in a source file due to design decisions of 
+class rll_wrapper_c {
+public:
+   //! \brief THe definition of the thrown errors also needs
+   //         to be hidden as it would cause include issues so
+   //         we need to wrap that too
+   class library_loading_error_c : public std::exception {
+    public:
+      library_loading_error_c() = delete;
+      library_loading_error_c(const char* what) : _what(what) {}
+      const char *what() const throw() { return _what; }
+    private:
+      const char* _what;
+   };
+
+   //! \brief Create the wrapper
+   rll_wrapper_c();
+
+   //! \brief wrap rll::shared_library::load
+   void load(std::string target);
+
+   //! \brief wrap rll::shared_library::is_loaded
+   bool is_loaded();
+
+   //! \brief wrap rll::shared_library::has_symbol
+   bool has_symbol(std::string symbol);
+
+   //! \brief wrap rll::shared_library::get_symbol
+   void* get_symbol(std::string symbol);
+private:
+   std::shared_ptr<rll::shared_library> _lib;
+};
+
+using rll_map = phmap::parallel_node_hash_map<std::string, std::shared_ptr<rll_wrapper_c>>;
+}
+
+#endif

--- a/src/libsauros/sauros/RLL/rll_wrapper.hpp
+++ b/src/libsauros/sauros/RLL/rll_wrapper.hpp
@@ -1,9 +1,9 @@
 #ifndef SAUROS_RLL_WRAPPER
 #define SAUROS_RLL_WRAPPER
 
+#include "sauros/parallel_hashmap/phmap.hpp"
 #include <memory>
 #include <string>
-#include "sauros/parallel_hashmap/phmap.hpp"
 
 // Forward declaration for RLL library loader
 namespace rll {
@@ -11,21 +11,22 @@ class shared_library;
 }
 
 namespace sauros {
-   
+
 //! \brief A wrapper fo the rll lib as the header can only be included
-//!        once in a source file due to design decisions of 
+//!        once in a source file due to design decisions of
 class rll_wrapper_c {
-public:
+ public:
    //! \brief THe definition of the thrown errors also needs
    //         to be hidden as it would cause include issues so
    //         we need to wrap that too
    class library_loading_error_c : public std::exception {
     public:
       library_loading_error_c() = delete;
-      library_loading_error_c(const char* what) : _what(what) {}
+      library_loading_error_c(const char *what) : _what(what) {}
       const char *what() const throw() { return _what; }
+
     private:
-      const char* _what;
+      const char *_what;
    };
 
    //! \brief Create the wrapper
@@ -41,12 +42,14 @@ public:
    bool has_symbol(std::string symbol);
 
    //! \brief wrap rll::shared_library::get_symbol
-   void* get_symbol(std::string symbol);
-private:
+   void *get_symbol(std::string symbol);
+
+ private:
    std::shared_ptr<rll::shared_library> _lib;
 };
 
-using rll_map = phmap::parallel_node_hash_map<std::string, std::shared_ptr<rll_wrapper_c>>;
-}
+using rll_map =
+    phmap::parallel_node_hash_map<std::string, std::shared_ptr<rll_wrapper_c>>;
+} // namespace sauros
 
 #endif

--- a/src/libsauros/sauros/cell.hpp
+++ b/src/libsauros/sauros/cell.hpp
@@ -97,7 +97,7 @@ class cell_c {
    std::string data;
    cell_type_e type{cell_type_e::SYMBOL};
    location_s location;
-   proc_f proc;
+   proc_f proc{nullptr};
    cells_t list;
    bool stop_processing{false};
    std::shared_ptr<environment_c> box_env{nullptr};

--- a/src/libsauros/sauros/driver.cpp
+++ b/src/libsauros/sauros/driver.cpp
@@ -127,7 +127,7 @@ std::optional<std::string> input_buffer_c::submit(std::string &line) {
    return {};
 }
 
-driver_if::driver_if(std::shared_ptr<sauros::environment_c> &env) : _env(env) {
+driver_if::driver_if(std::shared_ptr<sauros::environment_c> env) : _env(env) {
    _buffer = new input_buffer_c();
 }
 

--- a/src/libsauros/sauros/driver.hpp
+++ b/src/libsauros/sauros/driver.hpp
@@ -19,7 +19,7 @@ class driver_if {
 
    //! \brief Create the driver
    //! \param env The environment
-   driver_if(std::shared_ptr<sauros::environment_c> &env);
+   driver_if(std::shared_ptr<sauros::environment_c> env);
 
  protected:
    void execute(const char *source, const uint64_t line_number,
@@ -31,7 +31,7 @@ class driver_if {
    virtual void except(sauros::environment_c::unknown_identifier_c &e) = 0;
    virtual void parser_error(std::string &e, location_s location) = 0;
 
-   std::shared_ptr<sauros::environment_c> &_env;
+   std::shared_ptr<sauros::environment_c> _env;
    sauros::input_buffer_c *_buffer{nullptr};
    sauros::processor_c _list_processor;
    parser::segment_parser_c _segment_parser;
@@ -45,7 +45,7 @@ class file_executor_c : private driver_if {
 
    //! \brief Create the executor
    //! \param env The environment to use
-   file_executor_c(std::shared_ptr<sauros::environment_c> &env)
+   file_executor_c(std::shared_ptr<sauros::environment_c> env)
        : driver_if(env) {}
 
    //! \brief Load and execute the file
@@ -77,7 +77,7 @@ class repl_c : private driver_if {
 
    //! \brief Create the repl object
    //! \param env The environment to use
-   repl_c(std::shared_ptr<sauros::environment_c> &env) : driver_if(env) {}
+   repl_c(std::shared_ptr<sauros::environment_c> env) : driver_if(env) {}
 
    //! \brief Start the REPL
    void start();
@@ -106,7 +106,7 @@ class eval_c : private driver_if {
    //! \brief Create the repl object
    //! \param env The environment to use
    //! \param cb The callback to issue when the cell is returned
-   eval_c(std::shared_ptr<sauros::environment_c> &env,
+   eval_c(std::shared_ptr<sauros::environment_c> env,
           std::function<void(cell_ptr cell)> cb)
        : driver_if(env), _cb(cb) {}
 

--- a/src/libsauros/sauros/environment.cpp
+++ b/src/libsauros/sauros/environment.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 
+
 namespace sauros {
 
 bool environment_c::exists(const std::string &item) {
@@ -43,6 +44,20 @@ environment_c *environment_c::find(const std::string &var,
    }
 
    throw unknown_identifier_c(var, location);
+}
+
+bool environment_c::package_loaded(const std::string &package) {
+   if (_loaded_packages.find(package) != _loaded_packages.end()) {
+      return true;
+   }
+   if (_parent) {
+      return _parent->package_loaded(package);
+   }
+   return false;
+}
+
+void environment_c::save_package(const std::string &name, std::shared_ptr<rll_wrapper_c> lib) {
+   _loaded_packages[name] = lib;
 }
 
 } // namespace sauros

--- a/src/libsauros/sauros/environment.cpp
+++ b/src/libsauros/sauros/environment.cpp
@@ -2,7 +2,6 @@
 
 #include <iostream>
 
-
 namespace sauros {
 
 bool environment_c::exists(const std::string &item) {
@@ -56,7 +55,8 @@ bool environment_c::package_loaded(const std::string &package) {
    return false;
 }
 
-void environment_c::save_package(const std::string &name, std::shared_ptr<rll_wrapper_c> lib) {
+void environment_c::save_package(const std::string &name,
+                                 std::shared_ptr<rll_wrapper_c> lib) {
    _loaded_packages[name] = lib;
 }
 

--- a/src/libsauros/sauros/environment.hpp
+++ b/src/libsauros/sauros/environment.hpp
@@ -7,8 +7,8 @@
 
 #include <iostream>
 
-#include "cell_map.hpp"
 #include "RLL/rll_wrapper.hpp"
+#include "cell_map.hpp"
 
 namespace sauros {
 
@@ -84,7 +84,8 @@ class environment_c {
 
    bool package_loaded(const std::string &package);
 
-   void save_package(const std::string &name, std::shared_ptr<rll_wrapper_c> lib);
+   void save_package(const std::string &name,
+                     std::shared_ptr<rll_wrapper_c> lib);
 
  private:
    std::shared_ptr<environment_c> _parent{nullptr};

--- a/src/libsauros/sauros/environment.hpp
+++ b/src/libsauros/sauros/environment.hpp
@@ -8,6 +8,7 @@
 #include <iostream>
 
 #include "cell_map.hpp"
+#include "RLL/rll_wrapper.hpp"
 
 namespace sauros {
 
@@ -81,9 +82,14 @@ class environment_c {
    //! \brief Retrieve a copy of the env map
    cell_map_t get_map() const { return _env; }
 
+   bool package_loaded(const std::string &package);
+
+   void save_package(const std::string &name, std::shared_ptr<rll_wrapper_c> lib);
+
  private:
    std::shared_ptr<environment_c> _parent{nullptr};
    cell_map_t _env;
+   rll_map _loaded_packages;
 };
 
 } // namespace sauros

--- a/src/libsauros/sauros/processor/processor.cpp
+++ b/src/libsauros/sauros/processor/processor.cpp
@@ -112,7 +112,9 @@ void processor_c::quote_cell(std::string &out, cell_ptr cell,
    }
 }
 
-processor_c::processor_c() { populate_standard_builtins(); }
+processor_c::processor_c() { 
+   populate_standard_builtins(); 
+}
 
 cell_ptr processor_c::process_list(cells_t &cells,
                                    std::shared_ptr<environment_c> env) {
@@ -205,7 +207,6 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
           cell->builtin_encoding >= BUILTIN_ENTRY_COUNT) {
          throw runtime_exception_c("Invalid encoded symbol for : " + cell->data,
                                    cell->location);
-         return {};
       }
 
       // Direct access - no more mapping
@@ -229,7 +230,10 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
    default:
       break;
    }
-   return {};
+
+   throw runtime_exception_c(
+      "internal error -> no processable cell", cell->location
+   );
 }
 
 cell_ptr processor_c::process_lambda(cell_ptr cell, cells_t &cells,

--- a/src/libsauros/sauros/processor/processor.cpp
+++ b/src/libsauros/sauros/processor/processor.cpp
@@ -112,9 +112,7 @@ void processor_c::quote_cell(std::string &out, cell_ptr cell,
    }
 }
 
-processor_c::processor_c() { 
-   populate_standard_builtins(); 
-}
+processor_c::processor_c() { populate_standard_builtins(); }
 
 cell_ptr processor_c::process_list(cells_t &cells,
                                    std::shared_ptr<environment_c> env) {
@@ -231,9 +229,8 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
       break;
    }
 
-   throw runtime_exception_c(
-      "internal error -> no processable cell", cell->location
-   );
+   throw runtime_exception_c("internal error -> no processable cell",
+                             cell->location);
 }
 
 cell_ptr processor_c::process_lambda(cell_ptr cell, cells_t &cells,

--- a/src/libsauros/sauros/processor/processor.hpp
+++ b/src/libsauros/sauros/processor/processor.hpp
@@ -14,16 +14,12 @@
 #include <set>
 #include <vector>
 
-// Forward declaration for RLL library loader
-namespace rll {
-class shared_library;
-}
-
 namespace sauros {
 
 //! \brief A list processor
 class processor_c {
  public:
+
    //!\brief An exception that will be thrown on assertion failure
    class assertion_exception_c : public std::exception {
     public:
@@ -72,7 +68,6 @@ class processor_c {
 
    //! \brief Construct the processor
    processor_c();
-   ~processor_c();
 
    //! \brief Process a cell (generated from parser, or otherwise)
    //! \param cell The cell to process
@@ -92,8 +87,6 @@ class processor_c {
  private:
    sauros::system_c _system;
    std::array<cell_ptr, BUILTIN_ENTRY_COUNT> _builtins;
-   phmap::parallel_node_hash_map<std::string, rll::shared_library *>
-       _loaded_packages;
 
    void populate_standard_builtins();
 

--- a/src/libsauros/sauros/processor/processor.hpp
+++ b/src/libsauros/sauros/processor/processor.hpp
@@ -19,7 +19,6 @@ namespace sauros {
 //! \brief A list processor
 class processor_c {
  public:
-
    //!\brief An exception that will be thrown on assertion failure
    class assertion_exception_c : public std::exception {
     public:


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [x] Branch name details the work done for the PR
- [x] CI tests have passed
- [x] An admin has reviewed and accepted the PR
- [x] Clang format has been run on changes (`run format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)


## Description of work:

Please enter a description of your work here:
```
I discovered a bug with how packages are loaded from files that are imported (edgy)

**[file0.sau]**
--------------------
[use "dbg"]
[putln [dbg._pkg_dbg_]]
[var x::fn [lambda [][block   
   [putln [dbg._pkg_dbg_]]
]]]




**[file1.sau]**
--------------------
[import "file0.sau"]
[x::fn]


------------------------

The above would case a seg fault. This was because the import method created a temporary processor that would then load rll::shared_library pointers into a map, deleting them once processor's lifetime was up. These pointers were copied to a more permanent environment where they would be called (_pkg_dbg_) and be pointing to nothing. 

This was fixed by wrapping rll in a new class and storing loaded package pointers inside the environment object. Now processors create an rll_wrapper, populate it, then save it to the environment. 
```