### PR TITLE
origin file tracking

### DIFF
--- a/pkgs/fmt/fmt.cpp
+++ b/pkgs/fmt/fmt.cpp
@@ -55,8 +55,7 @@ _pkg_fmt_format_encode_(sauros::cells_t &cells,
 
    if (raw_target->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "format string expects source cell to be a string",
-          raw_target->location);
+          "format string expects source cell to be a string", raw_target);
    }
 
    auto target = raw_target->data;
@@ -84,8 +83,7 @@ _pkg_fmt_format_encode_(sauros::cells_t &cells,
       if (c == '\\') {
          if (i == target.size() - 1) {
             throw sauros::processor_c::runtime_exception_c(
-                "formated string ends with escape character",
-                cells[1]->location);
+                "formated string ends with escape character", cells[1]);
          }
          check_buffer(buffer, target[i + 1]);
          i++;
@@ -95,8 +93,7 @@ _pkg_fmt_format_encode_(sauros::cells_t &cells,
       if (c == '%') {
          if (emplaced >= source_cells.size()) {
             throw sauros::processor_c::runtime_exception_c(
-                "not enough source cells given to format string",
-                cells[1]->location);
+                "not enough source cells given to format string", cells[1]);
          }
 
          auto result = c_api_cell_to_string(source_cells[emplaced++], env);
@@ -119,8 +116,7 @@ _pkg_fmt_format_string_(sauros::cells_t &cells,
 
    if (raw_target->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "format string expects source cell to be a string",
-          raw_target->location);
+          "format string expects source cell to be a string", raw_target);
    }
 
    auto target = raw_target->data;
@@ -133,8 +129,7 @@ _pkg_fmt_format_string_(sauros::cells_t &cells,
       if (c == '\\') {
          if (i == target.size() - 1) {
             throw sauros::processor_c::runtime_exception_c(
-                "formated string ends with escape character",
-                cells[1]->location);
+                "formated string ends with escape character", cells[1]);
          }
          check_buffer(buffer, target[i + 1]);
          i++;

--- a/pkgs/math/math.cpp
+++ b/pkgs/math/math.cpp
@@ -11,7 +11,7 @@ sauros::cell_ptr single_arithmetic(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "given math function expects 1 parameter, but " +
               std::to_string(cells.size() - 1) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto op = [=](sauros::cell_ptr cell,
@@ -21,7 +21,7 @@ sauros::cell_ptr single_arithmetic(sauros::cells_t &cells,
           item->type != sauros::cell_type_e::INTEGER) {
          throw sauros::processor_c::runtime_exception_c(
              "math operation expects parameter to be an integer or a double",
-             cell->location);
+             cell);
       }
 
       return fn(std::stod(item->data));
@@ -187,7 +187,7 @@ _sauros_pkg_math_pow_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "given math function expects 3 parameter, but " +
               std::to_string(cells.size()) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto op = [=](sauros::cell_ptr &lhs_, sauros::cell_ptr &rhs_,
@@ -197,7 +197,7 @@ _sauros_pkg_math_pow_(sauros::cells_t &cells,
           lhs->type != sauros::cell_type_e::INTEGER) {
          throw sauros::processor_c::runtime_exception_c(
              "math operation expects parameter to be an integer or a double",
-             lhs->location);
+             lhs);
       }
 
       auto rhs = c_api_process_cell(rhs_, env);
@@ -205,7 +205,7 @@ _sauros_pkg_math_pow_(sauros::cells_t &cells,
           rhs->type != sauros::cell_type_e::INTEGER) {
          throw sauros::processor_c::runtime_exception_c(
              "math operation expects parameter to be an integer or a double",
-             rhs->location);
+             rhs);
       }
       return pow(std::stod(lhs->data), std::stod(rhs->data));
    };

--- a/pkgs/os/os.cpp
+++ b/pkgs/os/os.cpp
@@ -46,8 +46,7 @@ sauros::cell_ptr execute_commands(sauros::cells_t &cells,
 
       if (s->type != sauros::cell_type_e::STRING) {
          throw sauros::processor_c::runtime_exception_c(
-             cmd_name + " command expectes strings for all items",
-             cells[0]->location);
+             cmd_name + " command expectes strings for all items", cells[0]);
       }
       // Indicate the path being listed
       current_dir->list.push_back(s);
@@ -87,8 +86,7 @@ sauros::cell_ptr _pkg_os_ls_(sauros::cells_t &cells,
 
       if (s->type != sauros::cell_type_e::STRING) {
          throw sauros::processor_c::runtime_exception_c(
-             "ls command expectes strings for all sources to list",
-             cells[0]->location);
+             "ls command expectes strings for all sources to list", cells[0]);
       }
       // Indicate the path being listed
       current_dir->list.push_back(s);
@@ -117,7 +115,7 @@ sauros::cell_ptr _pkg_os_chdir_(sauros::cells_t &cells,
    auto raw_dest = c_api_process_cell(cells[1], env);
    if (raw_dest->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "chdir command expects parameter to be a string", cells[0]->location);
+          "chdir command expects parameter to be a string", cells[0]);
    }
 
    if (!std::filesystem::is_directory(raw_dest->data)) {
@@ -182,8 +180,7 @@ sauros::cell_ptr _pkg_os_is_file_(sauros::cells_t &cells,
    auto raw_dest = c_api_process_cell(cells[1], env);
    if (raw_dest->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "is_file command expects parameter to be a string",
-          cells[0]->location);
+          "is_file command expects parameter to be a string", cells[0]);
    }
 
    if (std::filesystem::is_block_file(raw_dest->data) ||
@@ -200,8 +197,7 @@ sauros::cell_ptr _pkg_os_is_dir_(sauros::cells_t &cells,
    auto raw_dest = c_api_process_cell(cells[1], env);
    if (raw_dest->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "is_dir command expects parameter to be a string",
-          cells[0]->location);
+          "is_dir command expects parameter to be a string", cells[0]);
    }
 
    if (std::filesystem::is_directory(raw_dest->data)) {
@@ -216,8 +212,7 @@ sauros::cell_ptr _pkg_os_exists_(sauros::cells_t &cells,
    auto raw_dest = c_api_process_cell(cells[1], env);
    if (raw_dest->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "is_file command expects parameter to be a string",
-          cells[0]->location);
+          "is_file command expects parameter to be a string", cells[0]);
    }
 
    if (std::filesystem::exists(raw_dest->data)) {
@@ -260,8 +255,7 @@ sauros::cell_ptr _pkg_os_copy_(sauros::cells_t &cells,
    auto source = c_api_process_cell(cells[1], env);
    if (source->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "copy command expects source parameter to be a string",
-          cells[1]->location);
+          "copy command expects source parameter to be a string", cells[1]);
    }
 
    if (!std::filesystem::exists(source->data)) {
@@ -272,14 +266,13 @@ sauros::cell_ptr _pkg_os_copy_(sauros::cells_t &cells,
    if (dest->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
           "copy command expects destination parameter to be a string",
-          cells[2]->location);
+          cells[2]);
    }
 
    auto flags = c_api_process_cell(cells[3], env);
    if (flags->type != sauros::cell_type_e::BOX) {
       throw sauros::processor_c::runtime_exception_c(
-          "copy command expects flags parameter to be a box",
-          cells[3]->location);
+          "copy command expects flags parameter to be a box", cells[3]);
    }
 
    if (!flags->box_env->exists("recursive") ||
@@ -288,7 +281,7 @@ sauros::cell_ptr _pkg_os_copy_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "flags box missing required members (recursive, update_existing, "
           "directories_only)",
-          cells[3]->location);
+          cells[3]);
    }
 
    auto recursion_cell = flags->box_env->get("recursive");
@@ -304,7 +297,7 @@ sauros::cell_ptr _pkg_os_copy_(sauros::cells_t &cells,
        update_processed->type != sauros::cell_type_e::INTEGER ||
        dir_processed->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
-          "all copy flags must be an integer type", cells[3]->location);
+          "all copy flags must be an integer type", cells[3]);
    }
 
    std::filesystem::copy_options options;
@@ -329,8 +322,7 @@ _pkg_os_file_append_(sauros::cells_t &cells,
    auto file = c_api_process_cell(cells[1], env);
    if (file->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "file operation expects file name to be a string",
-          cells[1]->location);
+          "file operation expects file name to be a string", cells[1]);
    }
 
    std::ofstream out_file;
@@ -357,8 +349,7 @@ _pkg_os_file_write_(sauros::cells_t &cells,
    auto file = c_api_process_cell(cells[1], env);
    if (file->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "file operation expects file name to be a string",
-          cells[1]->location);
+          "file operation expects file name to be a string", cells[1]);
    }
 
    std::ofstream out_file;
@@ -385,8 +376,7 @@ _pkg_os_file_read_(sauros::cells_t &cells,
    auto file = c_api_process_cell(cells[1], env);
    if (file->type != sauros::cell_type_e::STRING) {
       throw sauros::processor_c::runtime_exception_c(
-          "file operation expects file name to be a string",
-          cells[1]->location);
+          "file operation expects file name to be a string", cells[1]);
    }
 
    std::ifstream in_file;

--- a/pkgs/random/random.cpp
+++ b/pkgs/random/random.cpp
@@ -38,15 +38,14 @@ _pkg_random_string_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "random::string function expects 1 parameters (length), but " +
               std::to_string(cells.size() - 1) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto len = c_api_process_cell(cells[1], env);
    if (len->type != sauros::cell_type_e::DOUBLE &&
        len->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
-          "random::string expects parameter `len` to be numerical",
-          cells[1]->location);
+          "random::string expects parameter `len` to be numerical", cells[1]);
    }
 
    int len_int = 0;
@@ -55,7 +54,7 @@ _pkg_random_string_(sauros::cells_t &cells,
    } catch (...) {
       throw sauros::processor_c::runtime_exception_c(
           "random::string failed to convert parameter to integer (stoi)",
-          cells[1]->location);
+          cells[1]);
    }
    return std::make_shared<sauros::cell_c>(
        sauros::cell_type_e::STRING, generate_random_string(ALL_CHARS, len_int));
@@ -68,7 +67,7 @@ _pkg_random_alpha_string_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "random::alpha_string function expects 1 parameters (length), but " +
               std::to_string(cells.size() - 1) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto len = c_api_process_cell(cells[1], env);
@@ -76,7 +75,7 @@ _pkg_random_alpha_string_(sauros::cells_t &cells,
        len->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
           "random::alpha_string expects parameter `len` to be numerical",
-          cells[1]->location);
+          cells[1]);
    }
 
    int len_int = 0;
@@ -85,7 +84,7 @@ _pkg_random_alpha_string_(sauros::cells_t &cells,
    } catch (...) {
       throw sauros::processor_c::runtime_exception_c(
           "random::alpha_string failed to convert parameter to integer (stoi)",
-          cells[1]->location);
+          cells[1]);
    }
    return std::make_shared<sauros::cell_c>(
        sauros::cell_type_e::STRING, generate_random_string(ALPHA_NUM, len_int));
@@ -100,7 +99,7 @@ _pkg_random_sourced_string_(sauros::cells_t &cells,
           "(source_string, "
           "length), but " +
               std::to_string(cells.size() - 1) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto src = c_api_process_cell(cells[1], env);
@@ -108,7 +107,7 @@ _pkg_random_sourced_string_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "random::sourced_string expects parameter `source_string` to be a "
           "string",
-          cells[1]->location);
+          cells[1]);
    }
 
    auto len = c_api_process_cell(cells[2], env);
@@ -116,7 +115,7 @@ _pkg_random_sourced_string_(sauros::cells_t &cells,
        len->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
           "random::sourced_string expects parameter `len` to be numerical",
-          cells[2]->location);
+          cells[2]);
    }
 
    int len_int = 0;
@@ -126,7 +125,7 @@ _pkg_random_sourced_string_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "random::sourced_string failed to convert parameter to integer "
           "(stoi)",
-          cells[2]->location);
+          cells[2]);
    }
    return std::make_shared<sauros::cell_c>(
        sauros::cell_type_e::STRING, generate_random_string(src->data, len_int));
@@ -140,7 +139,7 @@ _pkg_random_uniform_int_(sauros::cells_t &cells,
           "random::uniform_int function expects 2 parameters (min, "
           "max), but " +
               std::to_string(cells.size() - 1) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto min = c_api_process_cell(cells[1], env);
@@ -148,7 +147,7 @@ _pkg_random_uniform_int_(sauros::cells_t &cells,
        min->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_int expects parameter `min` to be numerical",
-          cells[1]->location);
+          cells[1]);
    }
 
    auto max = c_api_process_cell(cells[2], env);
@@ -156,7 +155,7 @@ _pkg_random_uniform_int_(sauros::cells_t &cells,
        max->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_int expects parameter `max` to be numerical",
-          cells[2]->location);
+          cells[2]);
    }
 
    int min_int = 0;
@@ -168,14 +167,14 @@ _pkg_random_uniform_int_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_int failed to convert parameters to integers "
           "(stoi)",
-          cells[2]->location);
+          cells[2]);
    }
 
    if (min_int >= max_int) {
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_int minimum value must be less than maximum "
           "value",
-          cells[2]->location);
+          cells[2]);
    }
 
    std::random_device rd;
@@ -194,7 +193,7 @@ _pkg_random_uniform_real_(sauros::cells_t &cells,
           "random::uniform_real function expects 2 parameters (min, "
           "max), but " +
               std::to_string(cells.size() - 1) + " were given",
-          cells[0]->location);
+          cells[0]);
    }
 
    auto min = c_api_process_cell(cells[1], env);
@@ -202,7 +201,7 @@ _pkg_random_uniform_real_(sauros::cells_t &cells,
        min->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_real expects parameter `min` to be numerical",
-          cells[1]->location);
+          cells[1]);
    }
 
    auto max = c_api_process_cell(cells[2], env);
@@ -210,7 +209,7 @@ _pkg_random_uniform_real_(sauros::cells_t &cells,
        max->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_real expects parameter `max` to be numerical",
-          cells[2]->location);
+          cells[2]);
    }
 
    double min_int = 0;
@@ -222,14 +221,14 @@ _pkg_random_uniform_real_(sauros::cells_t &cells,
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_real failed to convert parameters to "
           "integers (stoi)",
-          cells[2]->location);
+          cells[2]);
    }
 
    if (min_int >= max_int) {
       throw sauros::processor_c::runtime_exception_c(
           "random::uniform_real minimum value must be less than maximum "
           "value",
-          cells[2]->location);
+          cells[2]);
    }
 
    std::random_device rd;

--- a/pkgs/time/time.cpp
+++ b/pkgs/time/time.cpp
@@ -16,14 +16,12 @@ uint64_t diff(sauros::cells_t &cells,
    auto raw_start = c_api_process_cell(cells[1], env);
    if (raw_start->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
-          "diff command requires start time to be an integer",
-          cells[1]->location);
+          "diff command requires start time to be an integer", cells[1]);
    }
    auto raw_end = c_api_process_cell(cells[2], env);
    if (raw_end->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
-          "diff command requires end time to be an integer",
-          cells[2]->location);
+          "diff command requires end time to be an integer", cells[2]);
    }
 
    auto start_actual = std::stoull(raw_start->data);
@@ -54,7 +52,7 @@ _pkg_time_stamp_to_utc_(sauros::cells_t &cells,
    auto raw_time = c_api_process_cell(cells[1], env);
    if (raw_time->type != sauros::cell_type_e::INTEGER) {
       throw sauros::processor_c::runtime_exception_c(
-          "time must be an integer for stamp_to_utc", cells[1]->location);
+          "time must be an integer for stamp_to_utc", cells[1]);
    }
    auto time_actual = std::stoull(raw_time->data);
    time_t time = time_actual / 1000;

--- a/src/libsauros/sauros/cell.hpp
+++ b/src/libsauros/sauros/cell.hpp
@@ -78,6 +78,14 @@ class cell_c {
    cell_c(cell_type_e type, const std::string &data, location_s location)
        : type(type), data(data), location(location) {}
 
+   //! \brief Create a standard cell
+   //! \param type The type to set
+   //! \param data The data to set
+   //! \param location The location in source that the cell originated from
+   cell_c(cell_type_e type, const std::string data, location_s location,
+          std::shared_ptr<std::string> origin)
+       : type(type), data(data), location(location), origin(origin) {}
+
    //! \brief Create a process cell
    //! \param proc The process function to set
    //! \note Process cells are declared as SYMBOL to reduce number of
@@ -102,6 +110,7 @@ class cell_c {
    bool stop_processing{false};
    std::shared_ptr<environment_c> box_env{nullptr};
    uint8_t builtin_encoding{BUILTIN_DEFAULT_VAL};
+   std::shared_ptr<std::string> origin{nullptr};
 };
 
 static const cell_c CELL_TRUE =

--- a/src/libsauros/sauros/environment.cpp
+++ b/src/libsauros/sauros/environment.cpp
@@ -33,16 +33,16 @@ void environment_c::set(const std::string &item, cell_ptr cell) {
 cell_ptr &environment_c::get(const std::string &item) { return _env[item]; }
 
 environment_c *environment_c::find(const std::string &var,
-                                   location_s location) {
+                                   cell_ptr origin_cell) {
 
    if (_env.find(var) != _env.end()) {
       return this;
    }
    if (_parent) {
-      return _parent->find(var, location);
+      return _parent->find(var, origin_cell);
    }
 
-   throw unknown_identifier_c(var, location);
+   throw unknown_identifier_c(var, origin_cell);
 }
 
 bool environment_c::package_loaded(const std::string &package) {

--- a/src/libsauros/sauros/environment.hpp
+++ b/src/libsauros/sauros/environment.hpp
@@ -23,19 +23,24 @@ class environment_c {
 
       //! \brief Create the exception
       //! \param identifier The identifier that was unknown
-      unknown_identifier_c(std::string identifier, location_s location)
-          : _id(identifier), _location(location) {}
+      unknown_identifier_c(std::string identifier, cell_ptr cell)
+          : _id(identifier), _cell(cell) {}
       const char *what() const throw() { return "Unknown identifier"; }
 
       //! \brief Retrieve the identifier that was requested
-      std::string get_id() const { return _id; }
+      const std::string get_id() const { return _id; }
 
       //! \brief Retrieve the location
-      location_s get_location() const { return _location; }
+      const location_s get_location() const { return _cell->location; }
+
+      //! \brief Retrieve the origin
+      const std::shared_ptr<std::string> get_origin() const {
+         return _cell->origin;
+      }
 
     private:
       std::string _id;
-      location_s _location;
+      cell_ptr _cell;
    };
 
    //! \brief Construct an environment
@@ -58,11 +63,14 @@ class environment_c {
    bool exists(const std::string &item);
 
    //! \brief Find the environment that contains the item (current item or a
-   //! parent super scope) \param item The item to find \returns environment
-   //! pointer that the item can be safely retrieved from using `get` \note If
-   //! the item is not reachable within the current, or parent scope(s)
+   //!        parent super scope)
+   //! \param item The item to find
+   //! \param origin_cell Cell with origin information
+   //! \returns environment pointer that the item can be safely retrieved from
+   //! using `get` \note If the item is not reachable within the current, or
+   //! parent scope(s)
    //!       then the exception `unknown_identifier_c` will be thrown
-   environment_c *find(const std::string &item, location_s location);
+   environment_c *find(const std::string &item, cell_ptr origin_cell);
 
    //! \brief Get an item
    //! \param item the item to get

--- a/src/libsauros/sauros/front/parser.hpp
+++ b/src/libsauros/sauros/front/parser.hpp
@@ -39,20 +39,26 @@ class parser_exception_c : public std::exception {
 
    //! \brief Construct the expception
    //! \param message The message that is to be displayed
+   //! \param origin The origin file of the error
    //! \param location The location (line/col) that the error arose
-   parser_exception_c(std::string message, location_s location)
-       : _msg(message), _loc(location) {}
+   parser_exception_c(std::string message, std::shared_ptr<std::string> origin,
+                      location_s location)
+       : _msg(message), _origin(origin), _loc(location) {}
 
    //! \brief Retrieve the description of the exception
    const char *what() const throw() { return _msg.c_str(); }
 
    //! \brief Retrieve the location (line/col) that caused the exception to
    //! be thrown
-   const location_s get_location() { return _loc; }
+   const location_s get_location() const { return _loc; }
+
+   //! \brief Retrieve the origin of the exception
+   const std::shared_ptr<std::string> get_origin() const { return _origin; }
 
  private:
    std::string _msg;
    location_s _loc{0, 0};
+   std::shared_ptr<std::string> _origin;
 };
 
 //! \brief A parser meant to parse segments of code
@@ -73,9 +79,15 @@ class segment_parser_c {
    //!        exists no more source
    void indicate_complete();
 
+   //! \brief Set the origin file the source so
+   //!        it can be encoded into the cells
+   //! \param origin THe origin of the cells
+   void set_origin(const std::string &origin);
+
  private:
    std::vector<token_s> _tokens;
    bracket_track_s _bts;
+   std::shared_ptr<std::string> _origin{nullptr};
 };
 
 //! \brief Parse a line

--- a/src/libsauros/sauros/processor/processor.cpp
+++ b/src/libsauros/sauros/processor/processor.cpp
@@ -89,7 +89,7 @@ void processor_c::quote_cell(std::string &out, cell_ptr cell,
       out += lambda_name + "[ ";
 
       auto target_lambda =
-          env->find(cells[0]->data, cells[0]->location)->get(cells[0]->data);
+          env->find(cells[0]->data, cells[0])->get(cells[0]->data);
 
       for (auto param = target_lambda->list[0]->list.begin() + 1;
            param != target_lambda->list[0]->list.end(); ++param) {
@@ -160,7 +160,7 @@ cell_ptr processor_c::process_list(cells_t &cells,
    default:
       break;
    }
-   throw runtime_exception_c("Unknown cell type", cells[0]->location);
+   throw runtime_exception_c("Unknown cell type", cells[0]);
 }
 
 std::vector<std::string>
@@ -191,7 +191,7 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
 
       // If not built in maybe it is in the environment
       //
-      auto env_with_data = env->find(cell->data, cell->location);
+      auto env_with_data = env->find(cell->data, cell);
       auto r = env_with_data->get(cell->data);
 
       if (r->type == cell_type_e::BOX) {
@@ -204,7 +204,7 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
       if (cell->builtin_encoding == BUILTIN_DEFAULT_VAL ||
           cell->builtin_encoding >= BUILTIN_ENTRY_COUNT) {
          throw runtime_exception_c("Invalid encoded symbol for : " + cell->data,
-                                   cell->location);
+                                   cell);
       }
 
       // Direct access - no more mapping
@@ -229,8 +229,7 @@ cell_ptr processor_c::process_cell(cell_ptr cell,
       break;
    }
 
-   throw runtime_exception_c("internal error -> no processable cell",
-                             cell->location);
+   throw runtime_exception_c("internal error -> no processable cell", cell);
 }
 
 cell_ptr processor_c::process_lambda(cell_ptr cell, cells_t &cells,
@@ -247,7 +246,7 @@ cell_ptr processor_c::process_lambda(cell_ptr cell, cells_t &cells,
           "Invalid number of paramters given to lambda: " + cells[0]->data +
               ". " + std::to_string(exps.size()) + " parameters given, but " +
               std::to_string(cell->list[0]->list.size()) + " were expected.",
-          cells[0]->location);
+          cells[0]);
    }
 
    // Create the lambda cell
@@ -279,7 +278,7 @@ cell_ptr processor_c::access_box_member(cell_ptr cell,
    auto accessors = retrieve_accessors(cell->data);
 
    if (accessors.size() <= 1) {
-      throw runtime_exception_c("Malformed accessor", cell->location);
+      throw runtime_exception_c("Malformed accessor", cell);
    }
 
    cell_ptr result;
@@ -287,7 +286,7 @@ cell_ptr processor_c::access_box_member(cell_ptr cell,
    for (std::size_t i = 0; i < accessors.size(); i++) {
 
       // Get the item from the accessor
-      auto containing_env = moving_env->find(accessors[i], cell->location);
+      auto containing_env = moving_env->find(accessors[i], cell);
       result = containing_env->get(accessors[i]);
 
       // Check if we need to move the environment "in" to the next box

--- a/src/libsauros/sauros/processor/processor.hpp
+++ b/src/libsauros/sauros/processor/processor.hpp
@@ -27,19 +27,24 @@ class processor_c {
       //! \brief Construct the expception
       //! \param message The message that is to be displayed
       //! \param location The location (line/col) that the error arose
-      assertion_exception_c(std::string label, location_s location)
-          : _label(label), _loc(location) {}
+      assertion_exception_c(std::string label, cell_ptr cell)
+          : _label(label), _cell(cell) {}
 
       //! \brief Retrieve the description of the exception
       const char *what() const throw() { return _label.c_str(); }
 
       //! \brief Retrieve the location (line/col) that caused the exception to
       //! be thrown
-      const location_s get_location() { return _loc; }
+      const location_s get_location() const { return _cell->location; }
+
+      //! \brief Retrieve the origin
+      const std::shared_ptr<std::string> get_origin() const {
+         return _cell->origin;
+      }
 
     private:
       std::string _label;
-      location_s _loc{0, 0};
+      cell_ptr _cell;
    };
 
    //!\brief An exception that can be thrown during processing
@@ -49,20 +54,25 @@ class processor_c {
 
       //! \brief Construct the expception
       //! \param message The message that is to be displayed
-      //! \param location The location (line/col) that the error arose
-      runtime_exception_c(std::string message, location_s location)
-          : _msg(message), _loc(location) {}
+      runtime_exception_c(std::string message, cell_ptr cell)
+          : _msg(message), _cell(cell) {}
 
       //! \brief Retrieve the description of the exception
       const char *what() const throw() { return _msg.c_str(); }
 
       //! \brief Retrieve the location (line/col) that caused the exception to
       //! be thrown
-      const location_s get_location() { return _loc; }
+      const location_s get_location() const { return _cell->location; }
+
+      //! \brief Retrieve the origin (file) that caused the exception to
+      //! be thrown - may be null
+      const std::shared_ptr<std::string> get_origin() const {
+         return _cell->origin;
+      }
 
     private:
       std::string _msg;
-      location_s _loc{0, 0};
+      cell_ptr _cell;
    };
 
    //! \brief Construct the processor

--- a/src/libsauros/sauros/processor/processor_arithmetic.cpp
+++ b/src/libsauros/sauros/processor/processor_arithmetic.cpp
@@ -8,7 +8,7 @@ cell_ptr processor_c::perform_arithmetic(
 
    if (cells.size() < 3) {
       throw runtime_exception_c("Expected a list size of at least 3 items",
-                                cells[0]->location);
+                                cells[0]);
    }
 
    double result = 0.0;
@@ -19,10 +19,10 @@ cell_ptr processor_c::perform_arithmetic(
       result = std::stod(first_cell_value->data);
    } catch (const std::invalid_argument &) {
       throw runtime_exception_c("Invalid data type given for operand",
-                                first_cell_value->location);
+                                first_cell_value);
    } catch (const std::out_of_range &) {
       throw runtime_exception_c("Item caused out of range exception",
-                                first_cell_value->location);
+                                first_cell_value);
    }
 
    for (auto i = cells.begin() + 2; i != cells.end(); ++i) {
@@ -31,18 +31,17 @@ cell_ptr processor_c::perform_arithmetic(
       if (cell_value->type == cell_type_e::DOUBLE) {
          store_as_double = true;
       } else if (cell_value->type != cell_type_e::INTEGER) {
-         throw runtime_exception_c("Invalid type for operand",
-                                   cell_value->location);
+         throw runtime_exception_c("Invalid type for operand", cell_value);
       }
 
       try {
          result = fn(result, std::stod(cell_value->data));
       } catch (const std::invalid_argument &) {
          throw runtime_exception_c("Invalid data type given for operand",
-                                   cell_value->location);
+                                   cell_value);
       } catch (const std::out_of_range &) {
          throw runtime_exception_c("Item caused out of range exception",
-                                   cell_value->location);
+                                   cell_value);
       }
    }
 

--- a/src/libsauros/sauros/processor/processor_load_package.cpp
+++ b/src/libsauros/sauros/processor/processor_load_package.cpp
@@ -27,9 +27,10 @@ void processor_c::load_package(const std::string &target, location_s location,
    auto sauros_home = _system.get_sauros_directory();
 
    if (!sauros_home.has_value()) {
-      throw runtime_exception_c("sauros home directory not found. please set "
-                                "SAUROS_HOME environment variable.",
-                                location);
+      throw runtime_exception_c(
+          "sauros home directory not found. please set "
+          "SAUROS_HOME environment variable.",
+          std::make_shared<cell_c>(cell_type_e::STRING, "", location));
    }
 
    std::filesystem::path target_manifest_file = (*sauros_home);
@@ -46,7 +47,7 @@ void processor_c::load_package(const std::string &target, location_s location,
    if (!std::filesystem::is_regular_file(target_manifest_file)) {
       throw runtime_exception_c(
           "unable to locate package file for given package: " + target,
-          location);
+          std::make_shared<cell_c>(cell_type_e::STRING, "", location));
    }
 
    // Now we load the manifest in a new processor and environment
@@ -56,9 +57,9 @@ void processor_c::load_package(const std::string &target, location_s location,
    {
       sauros::file_executor_c file_executor(package_load_env);
       if (0 != file_executor.run(target_manifest_file.c_str())) {
-         throw runtime_exception_c("unable to open file " +
-                                       std::string(target_manifest_file),
-                                   location);
+         throw runtime_exception_c(
+             "unable to open file " + std::string(target_manifest_file),
+             std::make_shared<cell_c>(cell_type_e::STRING, "", location));
       }
    }
 
@@ -78,14 +79,15 @@ void processor_c::load_package(const std::string &target, location_s location,
    {
       if (!package_load_env->exists("pkg_name")) {
          throw runtime_exception_c(
-             " target: " + target + " does not contain a pkg_name", location);
+             " target: " + target + " does not contain a pkg_name",
+             std::make_shared<cell_c>(cell_type_e::STRING, "", location));
       }
 
       auto package_name_cell = package_load_env->get("pkg_name");
       if (package_name_cell->type != cell_type_e::STRING) {
-         throw runtime_exception_c("pkg_name in pkg.sau for " + target +
-                                       " is not of type `STRING`",
-                                   location);
+         throw runtime_exception_c(
+             "pkg_name in pkg.sau for " + target + " is not of type `STRING`",
+             std::make_shared<cell_c>(cell_type_e::STRING, "", location));
       }
       package.name = package_name_cell->data;
 
@@ -98,7 +100,8 @@ void processor_c::load_package(const std::string &target, location_s location,
          sauros::file_executor_c file_executor(package.env);
          if (0 != file_executor.run(package_file.c_str())) {
             throw runtime_exception_c(
-                "unable to open file " + std::string(package_file), location);
+                "unable to open file " + std::string(package_file),
+                std::make_shared<cell_c>(cell_type_e::STRING, "", location));
          }
       }
 
@@ -109,9 +112,10 @@ void processor_c::load_package(const std::string &target, location_s location,
 
          auto library_file_cell = package.env->get("library_file");
          if (library_file_cell->type != cell_type_e::STRING) {
-            throw runtime_exception_c("library_file in package.sau for " +
-                                          target + " is not of type `STRING`",
-                                      location);
+            throw runtime_exception_c(
+                "library_file in package.sau for " + target +
+                    " is not of type `STRING`",
+                std::make_shared<cell_c>(cell_type_e::STRING, "", location));
          }
 
          // std::cout << "\t[library file] " << library_file_cell->data
@@ -124,7 +128,7 @@ void processor_c::load_package(const std::string &target, location_s location,
                throw runtime_exception_c(
                    "library file:" + library_file_actual.string() +
                        " for package: " + target + " does not exist",
-                   location);
+                   std::make_shared<cell_c>(cell_type_e::STRING, "", location));
             }
             package.library_file = library_file_actual.string();
          }
@@ -135,14 +139,15 @@ void processor_c::load_package(const std::string &target, location_s location,
                     " does not contain a library_functions list for library "
                     "listed as: " +
                     package.library_file,
-                location);
+                std::make_shared<cell_c>(cell_type_e::STRING, "", location));
          }
 
          auto library_functions_cell = package.env->get("library_functions");
          if (library_functions_cell->type != cell_type_e::LIST) {
-            throw runtime_exception_c("library_functions in package.sau for " +
-                                          target + " is not of type `LIST`",
-                                      location);
+            throw runtime_exception_c(
+                "library_functions in package.sau for " + target +
+                    " is not of type `LIST`",
+                std::make_shared<cell_c>(cell_type_e::STRING, "", location));
          }
 
          // Load teh functions
@@ -151,7 +156,7 @@ void processor_c::load_package(const std::string &target, location_s location,
                throw runtime_exception_c(
                    "function name listed in package.sau for " + target +
                        " is not of type `STRING`",
-                   location);
+                   std::make_shared<cell_c>(cell_type_e::STRING, "", location));
             }
             package.library_function_list.push_back(function_name_cell->data);
 
@@ -165,9 +170,10 @@ void processor_c::load_package(const std::string &target, location_s location,
       if (package.env->exists("source_files")) {
          auto source_files_cell = package.env->get("source_files");
          if (source_files_cell->type != cell_type_e::LIST) {
-            throw runtime_exception_c("source_files in package.sau for " +
-                                          target + " is not of type `LIST`",
-                                      location);
+            throw runtime_exception_c(
+                "source_files in package.sau for " + target +
+                    " is not of type `LIST`",
+                std::make_shared<cell_c>(cell_type_e::STRING, "", location));
          }
 
          // Load teh functions
@@ -176,7 +182,7 @@ void processor_c::load_package(const std::string &target, location_s location,
                throw runtime_exception_c(
                    "file name listed in package.sau for " + target +
                        " is not of type `STRING`",
-                   location);
+                   std::make_shared<cell_c>(cell_type_e::STRING, "", location));
             }
 
             {
@@ -186,7 +192,8 @@ void processor_c::load_package(const std::string &target, location_s location,
                   throw runtime_exception_c(
                       "source file:" + file_actual.string() +
                           " for package: " + package.name + " does not exist",
-                      location);
+                      std::make_shared<cell_c>(cell_type_e::STRING, "",
+                                               location));
                }
                package.source_file_list.push_back(file_actual);
             }
@@ -209,13 +216,15 @@ void processor_c::load_package(const std::string &target, location_s location,
    try {
       package_rll->load(package.library_file.c_str());
    } catch (rll_wrapper_c::library_loading_error_c &e) {
-      throw runtime_exception_c("error loading `" + target + "`: " + e.what(),
-                                location);
+      throw runtime_exception_c(
+          "error loading `" + target + "`: " + e.what(),
+          std::make_shared<cell_c>(cell_type_e::STRING, "", location));
    }
 
    if (!package_rll->is_loaded()) {
       throw runtime_exception_c(
-          "failed to load library: `" + package.library_file + "`", location);
+          "failed to load library: `" + package.library_file + "`",
+          std::make_shared<cell_c>(cell_type_e::STRING, "", location));
    }
 
    ;
@@ -230,7 +239,7 @@ void processor_c::load_package(const std::string &target, location_s location,
          throw runtime_exception_c(
              "error loading `" + target + "`: listed function `" + f +
                  "` was not found in `" + package.library_file.c_str() + "`",
-             location);
+             std::make_shared<cell_c>(cell_type_e::STRING, "", location));
       }
 
       void *fn_ptr = package_rll->get_symbol(f);
@@ -251,8 +260,9 @@ void processor_c::load_package(const std::string &target, location_s location,
 
       sauros::file_executor_c file_executor(boxed_cell->box_env);
       if (0 != file_executor.run(f)) {
-         throw runtime_exception_c("unable to open file " + std::string(f),
-                                   location);
+         throw runtime_exception_c(
+             "unable to open file " + std::string(f),
+             std::make_shared<cell_c>(cell_type_e::STRING, "", location));
       }
    }
 


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [x] Branch name details the work done for the PR
- [x] CI tests have passed
- [x] An admin has reviewed and accepted the PR
- [x] Clang format has been run on changes (`run format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)


## Description of work:

Please enter a description of your work here:
https://github.com/bosley/sauros/issues/53
```
Added a shared pointer to the cell object that points at its file name so when an error is nested in includes we can locate the actual file that it occurred in. This meant modifying all exceptions to take in a cell to pull origin and location, then updating the entire code base to use the correct exception constructor
```