### PR TITLE
change how imports work

### DIFF
--- a/examples/example_code/library_checkout_system/database/db.sau
+++ b/examples/example_code/library_checkout_system/database/db.sau
@@ -1,5 +1,5 @@
 [use "os"]
-[import "database/entry.sau"]
+[import "entry.sau"]
 
 ;  Load a database file
 ;


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [x] Branch name details the work done for the PR
- [x] CI tests have passed
- [x] An admin has reviewed and accepted the PR
- [x] Clang format has been run on changes (`run format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)


## Description of work:

Please enter a description of your work here:
```
Change how imports work so they search immediate paths as given in imports, followed by the path of the current file (sans file) with the import appeneded, and lastly, it searches the sauros home directory. 
```

https://github.com/bosley/sauros/issues/85